### PR TITLE
Refactor project structure and modules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,121 @@
+### Molecule Obsidian-like Project — Target Architecture
+
+This document proposes a modular, extensible architecture optimized for maintainability and growth. It separates concerns across core domain logic, UI, editor adapters, and extension APIs, and formalizes boundaries and extension points.
+
+## Monorepo Layout
+
+```text
+apps/
+  web/                     # App shell (routing, theme, composition)
+
+packages/
+  core/                    # Headless core (types, services, state, utils)
+    src/
+      types/               # Domain model (no React)
+      services/            # Feature services (Zustand stores + actions)
+      stores/              # Shared state slices (if separated from services)
+      utils/               # Pure helpers (e.g., panelTree)
+      plugin/              # Extension API contracts, registries
+      index.ts
+
+  editor/                  # Editor adapters (Monaco, Markdown, Diff)
+    src/
+      adapters/monaco/     # Monaco wrapper and options
+      features/markdown/   # Markdown editor impl
+      types/               # Editor-impl types
+      index.ts
+
+  ui/                      # UI library (React components, feature views)
+    src/
+      features/
+        workbench/
+        explorer/
+        search/
+        panels/            # Obsidian-like panel UI
+        obsidian-editor/   # Composition of Obsidian-like editor views
+      components/          # Reusable primitive components
+      hooks/               # UI hooks only
+      stores/              # UI-only state (view prefs, ephemeral)
+      styles/
+      providers/
+      types/               # UI-specific types (augmentations)
+      index.ts
+
+  extensions/              # First-party extensions (examples/tests)
+    src/
+      hello-world/
+      markdown-enhancer/
+      index.ts
+
+  themes/                  # Theme packs (JSON/CSS)
+    src/
+      default-dark/
+      default-light/
+      high-contrast/
+
+  fs/                      # FileSystem abstraction (optional)
+    src/
+      adapters/            # localStorage, IndexedDB, Node fs, WebDAV, etc.
+      index.ts
+```
+
+## Package Boundaries
+
+- core
+  - Owns domain types, services, and pure utilities
+  - No React components; Zustand is acceptable but React-free
+  - Exposes typed service hooks/selectors and extension contracts
+  - Example: `panelTree` logic, command service, menu service, extension service, search service, i18n service, theme service
+
+- editor
+  - Owns editor implementation details (Monaco, diff, language services)
+  - Exposes adapter interfaces for `core` services to call
+
+- ui
+  - Owns React components and feature views
+  - Depends on `core` for state/services and `editor` for editor components
+  - Contains only UI-specific state (e.g., transient view preferences)
+
+- extensions
+  - Owns extension modules consuming `core` contracts
+  - No direct dependency on `ui` components unless explicitly allowed via view contributions
+
+## Extension Points (Contributes)
+
+- Commands, Menus, Keybindings
+- Views (tree/webview/terminal), StatusBar, ActivityBar items
+- Themes, Locales, Settings schema
+- Editor contributions (language features, decorations)
+
+## State Management
+
+- Use Zustand slices per feature with explicit actions
+- Co-locate slice logic in `packages/core/src/services/<feature>/...`
+- UI consumes slices via typed hooks exposed by `core`
+- Avoid business logic in UI; keep UI declarative
+
+## Panel Tree Ownership
+
+- Source of truth in `core` under `utils/panelTree.ts`
+- Services operate on panel tree immutably; UI calls service actions
+- UI should avoid duplicating panel traversal/manipulation logic
+
+## Coding Conventions
+
+- Strong types for public APIs; no `any` in exported signatures
+- Feature-first directory structure in UI (`features/<feature>`)
+- Avoid deep nesting; prefer early returns and small functions
+- Keep React components presentational; move side-effects to hooks/services
+
+## Build & Distribution
+
+- Each package builds to ESM+CJS via tsup
+- `core` exports only type-safe public surface; internal folders remain private
+- `ui` re-exports only stable components and feature entry points
+
+## Testing Strategy
+
+- Unit tests in each package close to source
+- Integration tests in `apps/web` composing multiple packages
+- Contract tests for extension API stability
+

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,76 @@
+### Migration Guide — Toward Modular Architecture
+
+This guide lists practical steps to migrate the current codebase to the proposed structure with minimal breakage.
+
+## 1) Unify Types and Utilities
+
+- Move panel tree helpers into `packages/core/src/utils/panelTree.ts` (done)
+- Export helpers from `@dtinsight/molecule-core` root (done)
+- Replace UI-local `PanelNode` with `core` `PanelNode` type (in-progress; start with ObsidianLayout)
+
+Checklist:
+- [x] Core exports `panelTree` helpers
+- [ ] All UI components import `PanelNode` from core types
+- [ ] Remove duplicated UI `PanelNode` definitions
+
+## 2) Services vs UI Boundaries
+
+- Keep feature services and slices in `core/src/services`
+- UI invokes services via hooks from `@dtinsight/molecule-core`
+- Move any non-visual logic from UI components into service actions
+
+Checklist:
+- [ ] Audit UI components for business logic; move to services
+- [ ] Add missing services (e.g., workspace layouts, session recovery) in core
+
+## 3) Editor Adapters Package
+
+- Create `packages/editor` to encapsulate Monaco and other editor types
+- Expose `EditorView` and adapter interfaces so UI composes editor without coupling to Monaco details
+
+Checklist:
+- [ ] Extract `MonacoEditor` usage behind adapter in `packages/editor`
+- [ ] Replace direct `@monaco-editor/react` imports in UI
+
+## 4) Feature-First UI Structure
+
+- Move `components/obeditor` into `features/obsidian-editor`
+- Group related UI, hooks, and lightweight UI state under feature folder
+
+Checklist:
+- [ ] Create `packages/ui/src/features/obsidian-editor/*`
+- [ ] Update exports and imports
+
+## 5) Extension Contracts and Registries
+
+- Define extension contribution interfaces in `core/src/plugin`
+- Provide registries and lifecycle hooks (activate/deactivate)
+- Add example extensions in `packages/extensions`
+
+Checklist:
+- [ ] `core/plugin` contracts and basic registry
+- [ ] Example view/command/theme contributions
+
+## 6) Theming and I18n
+
+- Keep theme metadata and i18n catalogs in core types
+- UI reads current theme/locale from services; themes live in `packages/themes`
+
+Checklist:
+- [ ] Standardize theme type in core
+- [ ] Ensure `ui` uses theme service only
+
+## 7) Testing and CI
+
+- Add unit tests for `panelTree` helpers
+- Add integration tests for Obsidian-like panel operations via services
+
+Checklist:
+- [ ] panelTree unit tests
+- [ ] end-to-end panel interactions in `apps/web`
+
+## 8) Release Strategy
+
+- Version packages independently with changesets or keep turbo+pnpm workspace ranges
+- Stabilize core API first; mark UI APIs experimental until solidified
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,6 @@ export * from './stores';
 export * from './services';
 export * from './hooks';
 
+// Utilities
+export * from './utils/panelTree';
+

--- a/packages/core/src/utils/panelTree.ts
+++ b/packages/core/src/utils/panelTree.ts
@@ -1,0 +1,157 @@
+import type { PanelNode } from '../types';
+
+// Generic tab type used in panel operations. We only rely on id and isActive.
+type PanelTab = { id: string; isActive?: boolean } & Record<string, any>;
+
+export function findNodeById(node: PanelNode | undefined, id: string): PanelNode | null {
+  if (!node) return null;
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const child of node.children) {
+      const found = findNodeById(child, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function findFirstLeaf(node: PanelNode | undefined): PanelNode | null {
+  if (!node) return null;
+  if (node.type === 'leaf') return node;
+  for (const child of node.children || []) {
+    const found = findFirstLeaf(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function updateTabsForPanel(
+  tree: PanelNode,
+  panelId: string,
+  newTabs: PanelTab[]
+): PanelNode {
+  const visit = (node: PanelNode): PanelNode => {
+    if (node.id === panelId && node.type === 'leaf') {
+      return { ...node, tabs: newTabs as any };
+    }
+    if (node.children) {
+      return { ...node, children: node.children.map(visit) } as PanelNode;
+    }
+    return node;
+  };
+  return visit(tree);
+}
+
+export function addTabToPanelImmutable(
+  tree: PanelNode,
+  panelId: string,
+  tab: PanelTab,
+  makeActive = true
+): PanelNode {
+  const visit = (node: PanelNode): PanelNode => {
+    if (node.id === panelId && node.type === 'leaf') {
+      const tabs: PanelTab[] = (node.tabs as any as PanelTab[]) || [];
+      const nextTabs = tabs.map(t => ({ ...t, isActive: makeActive ? false : t.isActive }));
+      nextTabs.push({ ...tab, isActive: makeActive ? true : tab.isActive });
+      return { ...node, tabs: nextTabs as any };
+    }
+    if (node.children) return { ...node, children: node.children.map(visit) } as PanelNode;
+    return node;
+  };
+  return visit(tree);
+}
+
+export function activateTabInPanelImmutable(
+  tree: PanelNode,
+  panelId: string,
+  tabId: string
+): PanelNode {
+  const visit = (node: PanelNode): PanelNode => {
+    if (node.id === panelId && node.type === 'leaf' && node.tabs) {
+      const nextTabs = (node.tabs as any as PanelTab[]).map(t => ({ ...t, isActive: t.id === tabId }));
+      return { ...node, tabs: nextTabs as any };
+    }
+    if (node.children) return { ...node, children: node.children.map(visit) } as PanelNode;
+    return node;
+  };
+  return visit(tree);
+}
+
+export function closeTabInPanelImmutable(
+  tree: PanelNode,
+  panelId: string,
+  tabId: string
+): PanelNode {
+  const visit = (node: PanelNode): PanelNode => {
+    if (node.id === panelId && node.type === 'leaf' && node.tabs) {
+      const tabs: PanelTab[] = node.tabs as any;
+      const idx = tabs.findIndex(t => t.id === tabId);
+      if (idx === -1) return node;
+      const wasActive = !!tabs[idx].isActive;
+      const nextTabs = tabs.filter(t => t.id !== tabId);
+      if (wasActive && nextTabs.length > 0) {
+        nextTabs[nextTabs.length - 1] = { ...nextTabs[nextTabs.length - 1], isActive: true };
+      }
+      return { ...node, tabs: nextTabs as any };
+    }
+    if (node.children) return { ...node, children: node.children.map(visit) } as PanelNode;
+    return node;
+  };
+  return visit(tree);
+}
+
+export function splitPanelImmutable(
+  tree: PanelNode,
+  panelId: string,
+  direction: 'horizontal' | 'vertical',
+  createNewTab: () => PanelTab
+): PanelNode {
+  const visit = (node: PanelNode): PanelNode => {
+    if (node.id === panelId && node.type === 'leaf') {
+      const originalTabs: PanelTab[] = (node.tabs as any as PanelTab[]) || [];
+      const activeTab = originalTabs.find(t => t.isActive);
+      const newTab = activeTab ? { ...activeTab, id: `${activeTab.id}-copy-${Date.now()}`, isActive: true } : createNewTab();
+      const leftLeaf: PanelNode = { id: `${node.id}-a`, type: 'leaf', tabs: originalTabs as any, size: 50, minSize: 20 };
+      const rightLeaf: PanelNode = { id: `${node.id}-split-${Date.now()}`, type: 'leaf', tabs: [newTab] as any, size: 50, minSize: 20 };
+      return {
+        id: node.id,
+        type: 'split',
+        direction,
+        children: [leftLeaf, rightLeaf],
+        size: node.size,
+        minSize: node.minSize,
+      } as PanelNode;
+    }
+    if (node.children) return { ...node, children: node.children.map(visit) } as PanelNode;
+    return node;
+  };
+  return visit(tree);
+}
+
+export function removePanelNodeImmutable(tree: PanelNode, panelId: string): PanelNode {
+  function removeNode(node: PanelNode): PanelNode | null {
+    if (node.id === panelId) return null;
+    if (node.children) {
+      const newChildren = node.children
+        .map(child => removeNode(child))
+        .filter((child): child is PanelNode => child !== null);
+      if (newChildren.length === 1 && node.type === 'split') {
+        const only = newChildren[0];
+        return { ...only, size: node.size } as PanelNode;
+      }
+      return { ...node, children: newChildren } as PanelNode;
+    }
+    return node;
+  }
+
+  const result = removeNode(tree);
+  if (!result) {
+    return {
+      id: 'root',
+      type: 'leaf',
+      tabs: [{ id: `new-${Date.now()}`, title: '新标签页', isActive: true }] as any,
+    } as PanelNode;
+  }
+  return result;
+}
+


### PR DESCRIPTION
Extract panel tree utilities to `@dtinsight/molecule-core` and refactor `ObsidianLayout` to use them, along with introducing initial architecture and migration documentation, to improve modularity and reduce UI-core coupling.

---
<a href="https://cursor.com/background-agent?bcId=bc-c920ac1d-89ea-48c2-a567-2a44fc4e6217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c920ac1d-89ea-48c2-a567-2a44fc4e6217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

