### PR TITLE
Resolve duplicate workspace package

### DIFF
--- a/packages/core-new/package.json
+++ b/packages/core-new/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dtinsight/molecule-core",
+  "name": "@dtinsight/molecule-core-next",
   "version": "3.0.0-alpha.0",
   "description": "Core business logic and services for Molecule 3.x",
   "main": "dist/index.js",


### PR DESCRIPTION
Rename `@dtinsight/molecule-core` in `packages/core-new` to `@dtinsight/molecule-core-next` to resolve a duplicate workspace name conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-f48b756a-40d3-455a-9664-2a3765cca3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f48b756a-40d3-455a-9664-2a3765cca3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

