### PR TITLE
Fix missing module types for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "**" ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Enable corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.7.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Build
+        run: pnpm build
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,8 @@
       "@/*": ["./src/*"],
       "@dtinsight/molecule-core": ["./packages/core/src"],
       "@dtinsight/molecule-ui": ["./packages/ui/src"],
+      "@dtinsight/molecule-types": ["./packages/types/src"],
+      "@dtinsight/molecule-shared": ["./packages/shared/src"],
       "@dtinsight/molecule-editor": ["./packages/editor/src"],
       "@dtinsight/molecule-extensions": ["./packages/extensions/src"],
       "@dtinsight/molecule-themes": ["./packages/themes/src"]


### PR DESCRIPTION
Add TypeScript path aliases for internal modules and set up a CI workflow for automated builds.

This fixes the `TS2307: Cannot find module '@dtinsight/molecule-types'` error during local builds and ensures that type-checking and building are automatically run on all pull requests and pushes to `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9a73f3a-baeb-41fd-a964-9b6eb5d0845a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9a73f3a-baeb-41fd-a964-9b6eb5d0845a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

